### PR TITLE
Update license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "type": "git",
     "url": "https://github.com/viskin/marker-animate.git#node-friendly"
   },
-  "license": "LicenseRef-LICENSE",
+  "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
     "jquery": "*",
     "jquery-easing": "^0.0.1"


### PR DESCRIPTION
This tiny PR updates the license metadata to stay in line with recent changes to package.json license field guidelines in npm.

The relevant release notes are here: https://github.com/npm/npm/releases/tag/v2.12.0

Sorry for the back-and-forth on what to do about custom license terms, and thanks so much for taking the time to read the previous guidelines and note `LicenseRef-LICENSE`.
